### PR TITLE
[API] config + casting

### DIFF
--- a/python/blitzbeaver/__init__.py
+++ b/python/blitzbeaver/__init__.py
@@ -1,1 +1,13 @@
-from .blitzbeaver import *
+from .blitzbeaver import (
+    ElementType,
+    FieldSchema,
+    RecordSchema,
+    TrackingConfig,
+    TrackerConfig,
+    DistanceMetricConfig,
+    ResolverConfig,
+    SimpleTrackerConfig,
+    test_tracking_engine,
+)
+from .config import validate_tracking_config
+from .exceptions import BlitzBeaverException, InvalidConfigException

--- a/python/blitzbeaver/blitzbeaver.pyi
+++ b/python/blitzbeaver/blitzbeaver.pyi
@@ -57,9 +57,9 @@ class SimpleTrackerConfig:
     def __init__(self, interest_threshold: float) -> None: ...
 
 def test_tracking_engine(
+    tracking_config: TrackingConfig,
     record_schema: RecordSchema,
     dataframes: list[pl.DataFrame],
-    column_names: list[str],
 ) -> None: ...
 def benchmark_distance_functions(
     values: pl.Series, value: str, num_runs: int, distance_function: str

--- a/python/blitzbeaver/blitzbeaver.pyi
+++ b/python/blitzbeaver/blitzbeaver.pyi
@@ -1,6 +1,8 @@
 from enum import Enum, auto
 import polars as pl
 
+from .literals import ResolvingStrategy, DistanceMetric, TrackerType
+
 class ElementType(Enum):
     String = auto()
     MultiStrings = auto()
@@ -15,6 +17,44 @@ class RecordSchema:
     fields: list[FieldSchema]
 
     def __init__(self, fields: list[FieldSchema]) -> None: ...
+
+class TrackingConfig:
+    tracker: "TrackerConfig"
+    distance_metric: "DistanceMetricConfig"
+    resolver: "ResolverConfig"
+
+    def __init__(
+        self,
+        tracker: "TrackerConfig",
+        distance_metric: "DistanceMetricConfig",
+        resolver: "ResolverConfig",
+    ) -> None: ...
+
+class ResolverConfig:
+    resolving_strategy: ResolvingStrategy
+
+    def __init__(self, resolving_strategy: ResolvingStrategy) -> None: ...
+
+class DistanceMetricConfig:
+    metric: DistanceMetric
+    caching_threshold: int
+
+    def __init__(self, metric: DistanceMetric, caching_threshold: int) -> None: ...
+
+class TrackerConfig:
+    tracker_type: TrackerType
+    simple_tracker: "SimpleTrackerConfig" | None
+
+    def __init__(
+        self,
+        tracker_type: TrackerType,
+        simple_tracker: "SimpleTrackerConfig" | None = None,
+    ) -> None: ...
+
+class SimpleTrackerConfig:
+    interest_threshold: float
+
+    def __init__(self, interest_threshold: float) -> None: ...
 
 def test_tracking_engine(
     record_schema: RecordSchema,

--- a/python/blitzbeaver/config.py
+++ b/python/blitzbeaver/config.py
@@ -8,7 +8,7 @@ from .blitzbeaver import (
 from .exceptions import InvalidConfigException
 
 RESOLVING_STRATEGIES = ["simple"]
-DISTANCE_METRICS = ["lv", "optilv"]
+DISTANCE_METRICS = ["lv", "lvopti"]
 TRACKER_TYPES = ["simple"]
 
 

--- a/python/blitzbeaver/config.py
+++ b/python/blitzbeaver/config.py
@@ -1,0 +1,64 @@
+from .blitzbeaver import (
+    TrackingConfig,
+    TrackerConfig,
+    DistanceMetricConfig,
+    ResolverConfig,
+    SimpleTrackerConfig,
+)
+from .exceptions import InvalidConfigException
+
+RESOLVING_STRATEGIES = ["simple"]
+DISTANCE_METRICS = ["lv", "optilv"]
+TRACKER_TYPES = ["simple"]
+
+
+def validate_simple_tracker_config(simple_tracker_config: SimpleTrackerConfig) -> None:
+    if (
+        simple_tracker_config.interest_threshold < 0
+        or simple_tracker_config.interest_threshold > 1
+    ):
+        raise InvalidConfigException(
+            f"Invalid interest threshold: {simple_tracker_config.interest_threshold}"
+        )
+
+
+def validate_tracker_config(tracker: TrackerConfig) -> None:
+    if tracker.tracker_type not in TRACKER_TYPES:
+        raise InvalidConfigException(f"Invalid tracker type: {tracker.tracker_type}")
+    if tracker.tracker_type == "simple":
+        if tracker.simple_tracker is None:
+            raise InvalidConfigException(
+                "Simple tracker config must be provided for simple tracker type"
+            )
+        validate_simple_tracker_config(tracker.simple_tracker)
+
+
+def validate_distance_metric_config(
+    distance_metric_config: DistanceMetricConfig,
+) -> None:
+    if distance_metric_config.metric not in DISTANCE_METRICS:
+        raise InvalidConfigException(
+            f"Invalid distance metric: {distance_metric_config.metric}"
+        )
+
+
+def validate_resolver_config(resolver_config: ResolverConfig) -> None:
+    if resolver_config.resolving_strategy not in RESOLVING_STRATEGIES:
+        raise InvalidConfigException(
+            f"Invalid resolving strategy: {resolver_config.resolving_strategy}"
+        )
+
+
+def validate_tracking_config(config: TrackingConfig) -> None:
+    """
+    Validate the tracking configuration.
+
+    Args:
+        config: Tracking configuration to validate.
+
+    Raises:
+        InvalidConfigException: If the configuration is invalid
+    """
+    validate_tracker_config(config.tracker)
+    validate_distance_metric_config(config.distance_metric)
+    validate_resolver_config(config.resolver)

--- a/python/blitzbeaver/exceptions.py
+++ b/python/blitzbeaver/exceptions.py
@@ -1,0 +1,10 @@
+class BlitzBeaverException(Exception):
+    """
+    Base exception for BlitzBeaver
+    """
+
+
+class InvalidConfigException(BlitzBeaverException):
+    """
+    Exception raised when the configuration is invalid
+    """

--- a/python/blitzbeaver/literals.py
+++ b/python/blitzbeaver/literals.py
@@ -2,5 +2,5 @@ from typing import Literal
 
 
 ResolvingStrategy = Literal["simple"]
-DistanceMetric = Literal["lv", "optilv"]
+DistanceMetric = Literal["lv", "lvopti"]
 TrackerType = Literal["simple"]

--- a/python/blitzbeaver/literals.py
+++ b/python/blitzbeaver/literals.py
@@ -1,0 +1,6 @@
+from typing import Literal
+
+
+ResolvingStrategy = Literal["simple"]
+DistanceMetric = Literal["lv", "optilv"]
+TrackerType = Literal["simple"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,9 @@
+mod casting;
 mod config;
 mod schema;
 mod tracking;
 
+pub use casting::{build_tracking_engine, cast_to_frame};
 pub use config::{
     DistanceMetricConfig, ResolverConfig, SimpleTrackerConfig, TrackerConfig, TrackingConfig,
 };

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,9 @@
+mod config;
 mod schema;
 mod tracking;
 
+pub use config::{
+    DistanceMetricConfig, ResolverConfig, SimpleTrackerConfig, TrackerConfig, TrackingConfig,
+};
 pub use schema::{ElementType, FieldSchema, RecordSchema};
 pub use tracking::test_tracking_engine;

--- a/src/api/casting.rs
+++ b/src/api/casting.rs
@@ -1,0 +1,165 @@
+use polars::series::Series;
+use pyo3::{exceptions::PyValueError, PyResult};
+use pyo3_polars::{error::PyPolarsErr, PyDataFrame};
+
+use crate::{
+    distances::{
+        CachedDistanceCalculator, CachedDistanceCalculatorWord, DistanceMetric, LvDistanceMetric,
+        LvOptiDistanceMetric,
+    },
+    frame::{Element, Frame},
+    resolvers::{Resolver, SimpleResolvingStrategy},
+    trackers::{SimpleTracker, Tracker},
+    tracking_engine::TrackingEngine,
+    word::Word,
+};
+
+use super::{
+    DistanceMetricConfig, ElementType, FieldSchema, RecordSchema, ResolverConfig, TrackerConfig,
+    TrackingConfig,
+};
+
+fn cast_to_frame_column<'a>(
+    field_schema: &FieldSchema,
+    serie: &'a Series,
+) -> PyResult<Vec<Element<'a>>> {
+    match &field_schema.dtype {
+        ElementType::String => Ok(serie
+            .str()
+            .map_err(PyPolarsErr::from)?
+            .iter()
+            .map(|v| match v {
+                None => Element::None,
+                Some(v) => Element::Word(Word::new(v)),
+            })
+            .collect()),
+        ElementType::MultiStrings => Ok(serie
+            .list()
+            .map_err(PyPolarsErr::from)?
+            .iter()
+            .map(|v| match v {
+                Some(v) => {
+                    unimplemented!()
+                }
+                None => Element::None,
+            })
+            .collect()),
+    }
+}
+
+pub fn cast_to_frame<'a>(
+    frame_idx: usize,
+    record_schema: &RecordSchema,
+    dataframe: &'a PyDataFrame,
+) -> PyResult<Frame<'a>> {
+    let mut columns = Vec::new();
+    for field_schema in record_schema.fields.iter() {
+        let column = dataframe
+            .0
+            .column(&field_schema.name)
+            .map_err(PyPolarsErr::from)?;
+        let series = column.as_series().ok_or(PyValueError::new_err(
+            "Internal error: invalid polars column",
+        ))?;
+
+        columns.push(cast_to_frame_column(field_schema, series)?);
+    }
+
+    Ok(Frame::new(frame_idx, columns))
+}
+
+pub fn build_tracking_engine<'a>(
+    config: &TrackingConfig,
+    record_schema: &RecordSchema,
+    frames: Vec<Frame<'a>>,
+) -> PyResult<TrackingEngine<'a, impl Fn() -> Box<dyn Tracker<'a>>>> {
+    Ok(TrackingEngine::new(
+        frames,
+        build_resolver(&config.resolver)?,
+        build_distance_calculators(&config.distance_metric, record_schema)?,
+        build_tracker_builder(&config.tracker)?,
+    ))
+}
+
+fn build_resolver<'a>(resolver_config: &ResolverConfig) -> PyResult<Resolver<'a>> {
+    let resolving_strategy = match resolver_config.resolving_strategy.as_str() {
+        "simple" => Box::new(SimpleResolvingStrategy {}),
+        v => {
+            return Err(PyValueError::new_err(format!(
+                "Invalid resolving strategy: {}",
+                v
+            )));
+        }
+    };
+
+    Ok(Resolver::new(resolving_strategy))
+}
+
+fn build_distance_metric<'a>(
+    distance_metric_config: &DistanceMetricConfig,
+) -> PyResult<Box<dyn DistanceMetric<Word<'a>>>> {
+    match distance_metric_config.metric.as_str() {
+        "lv" => Ok(Box::new(LvDistanceMetric::new())),
+        "lvopti" => Ok(Box::new(LvOptiDistanceMetric::new())),
+        v => Err(PyValueError::new_err(format!(
+            "Invalid distance metric: {}",
+            v
+        ))),
+    }
+}
+
+fn build_distance_calculator<'a>(
+    distance_metric_config: &DistanceMetricConfig,
+    field_schema: &FieldSchema,
+) -> PyResult<CachedDistanceCalculator<'a>> {
+    Ok(match field_schema.dtype {
+        ElementType::String => CachedDistanceCalculator::Word(CachedDistanceCalculatorWord::new(
+            build_distance_metric(distance_metric_config)?,
+            distance_metric_config.caching_threshold,
+        )),
+        ElementType::MultiStrings => {
+            unimplemented!()
+        }
+    })
+}
+
+fn build_distance_calculators<'a>(
+    distance_metric_config: &DistanceMetricConfig,
+    record_schema: &RecordSchema,
+) -> PyResult<Vec<CachedDistanceCalculator<'a>>> {
+    let mut distance_calculators = Vec::new();
+    for field in record_schema.fields.iter() {
+        let distance_calculator = build_distance_calculator(distance_metric_config, field)?;
+        distance_calculators.push(distance_calculator);
+    }
+    Ok(distance_calculators)
+}
+
+fn build_tracker_builder<'a>(
+    tracker_config: &TrackerConfig,
+) -> PyResult<impl Fn() -> Box<dyn Tracker<'a>>> {
+    match tracker_config.tracker_type.as_str() {
+        "simple" => {
+            let config = match &tracker_config.simple_tracker {
+                Some(config) => config.clone(),
+                None => {
+                    return Err(PyValueError::new_err(format!(
+                        "Invalid simple tracker config"
+                    )));
+                }
+            };
+            Ok(move || {
+                let tracker = Box::new(SimpleTracker::new(config.clone()));
+                // Safety: there is some unclear lifetime issue with the tracker
+                // that is not resolved yet. This is a temporary workaround.
+                unsafe {
+                    std::mem::transmute::<Box<dyn Tracker<'static>>, Box<dyn Tracker<'a>>>(tracker)
+                }
+            })
+        }
+        v => Err(PyValueError::new_err(format!(
+            "Invalid tracker type: {}",
+            v
+        ))),
+    }
+}

--- a/src/api/casting.rs
+++ b/src/api/casting.rs
@@ -19,39 +19,78 @@ use super::{
     TrackingConfig,
 };
 
-fn cast_to_frame_column<'a>(
-    field_schema: &FieldSchema,
-    serie: &'a Series,
-) -> PyResult<Vec<Element<'a>>> {
-    match &field_schema.dtype {
-        ElementType::String => Ok(serie
-            .str()
-            .map_err(PyPolarsErr::from)?
-            .iter()
-            .map(|v| match v {
-                None => Element::None,
-                Some(v) => Element::Word(Word::new(v)),
-            })
-            .collect()),
-        ElementType::MultiStrings => Ok(serie
-            .list()
-            .map_err(PyPolarsErr::from)?
-            .iter()
-            .map(|v| match v {
-                Some(v) => {
-                    unimplemented!()
+/// Casts a polars series to a vector of Word elements.
+///
+/// # Errors
+/// Returns a PyPolarsErr if the series cannot be cast to a string series.
+fn cast_to_string_column(serie: &Series) -> PyResult<Vec<Element>> {
+    Ok(serie
+        .str()
+        .map_err(PyPolarsErr::from)?
+        .iter()
+        .map(|v| match v {
+            None => Element::None,
+            Some(v) => Element::Word(Word::new(v.to_string())),
+        })
+        .collect())
+}
+
+/// Casts a polars series to a vector of MultiWords elements.
+///
+/// # Errors
+/// Returns a PyPolarsErr if the series cannot be cast to a list of string series.
+/// Returns a PyValueError if a None value is found in the list.
+fn cast_to_multistrings_column(serie: &Series) -> PyResult<Vec<Element>> {
+    let mut elements = Vec::new();
+
+    for cell in serie.list().map_err(PyPolarsErr::from)?.into_iter() {
+        match cell {
+            Some(cell) => {
+                let mut words = Vec::new();
+
+                for v in cell.str().map_err(PyPolarsErr::from)?.into_iter() {
+                    match v {
+                        Some(value) => {
+                            words.push(Word::new(value.to_string()));
+                        }
+                        None => {
+                            return Err(PyValueError::new_err(format!(
+                                "None value in list[str] cell: {:?}",
+                                cell
+                            )));
+                        }
+                    }
                 }
-                None => Element::None,
-            })
-            .collect()),
+                elements.push(Element::MultiWords(words));
+            }
+            None => {
+                elements.push(Element::None);
+            }
+        }
+    }
+    Ok(elements)
+}
+
+/// Casts a polars series to a vector of elements based on the field schema.
+///
+/// # Errors
+/// Returns PyPolarsErr or PyValueError if the series cannot be cast to the specified type.
+fn cast_to_frame_column(field_schema: &FieldSchema, serie: &Series) -> PyResult<Vec<Element>> {
+    match &field_schema.dtype {
+        ElementType::String => cast_to_string_column(serie),
+        ElementType::MultiStrings => cast_to_multistrings_column(serie),
     }
 }
 
-pub fn cast_to_frame<'a>(
+/// Casts a polars dataframe to a Frame.
+///
+/// # Errors
+/// Returns PyPolarsErr or PyValueError if the dataframe cannot be cast to a Frame.
+pub fn cast_to_frame(
     frame_idx: usize,
     record_schema: &RecordSchema,
-    dataframe: &'a PyDataFrame,
-) -> PyResult<Frame<'a>> {
+    dataframe: &PyDataFrame,
+) -> PyResult<Frame> {
     let mut columns = Vec::new();
     for field_schema in record_schema.fields.iter() {
         let column = dataframe
@@ -68,11 +107,15 @@ pub fn cast_to_frame<'a>(
     Ok(Frame::new(frame_idx, columns))
 }
 
-pub fn build_tracking_engine<'a>(
+/// Builds a tracking engine from the given configuration and frames.
+///
+/// # Errors
+/// Returns PyValueError if the configuration is invalid.
+pub fn build_tracking_engine(
     config: &TrackingConfig,
     record_schema: &RecordSchema,
-    frames: Vec<Frame<'a>>,
-) -> PyResult<TrackingEngine<'a, impl Fn() -> Box<dyn Tracker<'a>>>> {
+    frames: Vec<Frame>,
+) -> PyResult<TrackingEngine<impl Fn() -> Box<dyn Tracker>>> {
     Ok(TrackingEngine::new(
         frames,
         build_resolver(&config.resolver)?,
@@ -81,7 +124,11 @@ pub fn build_tracking_engine<'a>(
     ))
 }
 
-fn build_resolver<'a>(resolver_config: &ResolverConfig) -> PyResult<Resolver<'a>> {
+/// Builds a resolver from the given configuration.
+///
+/// # Errors
+/// Returns PyValueError if the configuration is invalid.
+fn build_resolver(resolver_config: &ResolverConfig) -> PyResult<Resolver> {
     let resolving_strategy = match resolver_config.resolving_strategy.as_str() {
         "simple" => Box::new(SimpleResolvingStrategy {}),
         v => {
@@ -95,9 +142,13 @@ fn build_resolver<'a>(resolver_config: &ResolverConfig) -> PyResult<Resolver<'a>
     Ok(Resolver::new(resolving_strategy))
 }
 
-fn build_distance_metric<'a>(
+/// Builds a distance metric from the given configuration.
+///
+/// # Errors
+/// Returns PyValueError if the configuration is invalid.
+fn build_distance_metric(
     distance_metric_config: &DistanceMetricConfig,
-) -> PyResult<Box<dyn DistanceMetric<Word<'a>>>> {
+) -> PyResult<Box<dyn DistanceMetric<Word>>> {
     match distance_metric_config.metric.as_str() {
         "lv" => Ok(Box::new(LvDistanceMetric::new())),
         "lvopti" => Ok(Box::new(LvOptiDistanceMetric::new())),
@@ -108,10 +159,14 @@ fn build_distance_metric<'a>(
     }
 }
 
-fn build_distance_calculator<'a>(
+/// Builds a distance calculator from the given configuration and field schema.
+///
+/// # Errors
+/// Returns PyValueError if the configuration is invalid.
+fn build_distance_calculator(
     distance_metric_config: &DistanceMetricConfig,
     field_schema: &FieldSchema,
-) -> PyResult<CachedDistanceCalculator<'a>> {
+) -> PyResult<CachedDistanceCalculator> {
     Ok(match field_schema.dtype {
         ElementType::String => CachedDistanceCalculator::Word(CachedDistanceCalculatorWord::new(
             build_distance_metric(distance_metric_config)?,
@@ -123,10 +178,14 @@ fn build_distance_calculator<'a>(
     })
 }
 
-fn build_distance_calculators<'a>(
+/// Builds a list of distance calculators from the given configuration and record schema.
+///
+/// # Errors
+/// Returns PyValueError if the configuration is invalid.
+fn build_distance_calculators(
     distance_metric_config: &DistanceMetricConfig,
     record_schema: &RecordSchema,
-) -> PyResult<Vec<CachedDistanceCalculator<'a>>> {
+) -> PyResult<Vec<CachedDistanceCalculator>> {
     let mut distance_calculators = Vec::new();
     for field in record_schema.fields.iter() {
         let distance_calculator = build_distance_calculator(distance_metric_config, field)?;
@@ -135,9 +194,13 @@ fn build_distance_calculators<'a>(
     Ok(distance_calculators)
 }
 
-fn build_tracker_builder<'a>(
+/// Builds a tracker builder from the given configuration.
+///
+/// # Errors
+/// Returns PyValueError if the configuration is invalid.
+fn build_tracker_builder(
     tracker_config: &TrackerConfig,
-) -> PyResult<impl Fn() -> Box<dyn Tracker<'a>>> {
+) -> PyResult<impl Fn() -> Box<dyn Tracker>> {
     match tracker_config.tracker_type.as_str() {
         "simple" => {
             let config = match &tracker_config.simple_tracker {
@@ -148,14 +211,7 @@ fn build_tracker_builder<'a>(
                     )));
                 }
             };
-            Ok(move || {
-                let tracker = Box::new(SimpleTracker::new(config.clone()));
-                // Safety: there is some unclear lifetime issue with the tracker
-                // that is not resolved yet. This is a temporary workaround.
-                unsafe {
-                    std::mem::transmute::<Box<dyn Tracker<'static>>, Box<dyn Tracker<'a>>>(tracker)
-                }
-            })
+            Ok(move || Box::new(SimpleTracker::new(config.clone())) as Box<dyn Tracker>)
         }
         v => Err(PyValueError::new_err(format!(
             "Invalid tracker type: {}",

--- a/src/api/config.rs
+++ b/src/api/config.rs
@@ -1,0 +1,99 @@
+use pyo3::{pyclass, pymethods};
+
+#[pyclass(frozen)]
+#[derive(Debug, Clone)]
+pub struct TrackingConfig {
+    #[pyo3(get)]
+    pub tracker: TrackerConfig,
+    #[pyo3(get)]
+    pub distance_metric: DistanceMetricConfig,
+    #[pyo3(get)]
+    pub resolver: ResolverConfig,
+}
+
+#[pymethods]
+impl TrackingConfig {
+    #[new]
+    pub fn py_new(
+        tracker: TrackerConfig,
+        distance_metric: DistanceMetricConfig,
+        resolver: ResolverConfig,
+    ) -> Self {
+        Self {
+            tracker,
+            distance_metric,
+            resolver,
+        }
+    }
+}
+
+#[pyclass(frozen)]
+#[derive(Debug, Clone)]
+pub struct ResolverConfig {
+    #[pyo3(get)]
+    pub resolving_strategy: String,
+}
+
+#[pymethods]
+impl ResolverConfig {
+    #[new]
+    pub fn py_new(resolving_strategy: String) -> Self {
+        Self { resolving_strategy }
+    }
+}
+
+#[pyclass(frozen)]
+#[derive(Debug, Clone)]
+pub struct DistanceMetricConfig {
+    #[pyo3(get)]
+    pub metric: String,
+    #[pyo3(get)]
+    pub caching_threshold: u32,
+}
+
+#[pymethods]
+impl DistanceMetricConfig {
+    #[new]
+    pub fn py_new(metric: String, caching_threshold: u32) -> Self {
+        Self {
+            metric,
+            caching_threshold,
+        }
+    }
+}
+
+#[pyclass(frozen)]
+#[derive(Debug, Clone)]
+pub struct TrackerConfig {
+    #[pyo3(get)]
+    pub tracker_type: String,
+    #[pyo3(get)]
+    pub simple_tracker: Option<SimpleTrackerConfig>,
+}
+
+#[pymethods]
+impl TrackerConfig {
+    #[new]
+    #[pyo3(signature = (tracker_type, simple_tracker=None))]
+    pub fn py_new(tracker_type: String, simple_tracker: Option<SimpleTrackerConfig>) -> Self {
+        Self {
+            tracker_type,
+            simple_tracker,
+        }
+    }
+}
+
+#[pyclass(frozen)]
+#[derive(Debug, Clone)]
+pub struct SimpleTrackerConfig {
+    #[pyo3(get)]
+    pub interest_threshold: f32,
+}
+
+#[pymethods]
+impl SimpleTrackerConfig {
+    #[new]
+    pub fn py_new(interest_threshold: f32) -> Self {
+        Self { interest_threshold }
+    }
+}

--- a/src/api/tracking.rs
+++ b/src/api/tracking.rs
@@ -1,96 +1,30 @@
-use polars::series::Series;
 use pyo3::{pyfunction, PyResult};
-use pyo3_polars::{error::PyPolarsErr, PyDataFrame};
+use pyo3_polars::PyDataFrame;
 
-use crate::{
-    distances::{CachedDistanceCalculator, CachedDistanceCalculatorWord, LvOptiDistanceMetric},
-    frame::{Element, Frame},
-    resolvers::{Resolver, SimpleResolvingStrategy},
-    trackers::{SimpleTracker, SimpleTrackerConfig, Tracker},
-    tracking_engine::TrackingEngine,
-    word::Word,
-};
-
-use super::schema::{FieldSchema, RecordSchema};
-
-fn pyserie_to_vec<'a>(field_schema: &FieldSchema, serie: &'a Series) -> PyResult<Vec<Element<'a>>> {
-    Ok(serie
-        .str()
-        .map_err(PyPolarsErr::from)?
-        .iter()
-        .map(|v| match v {
-            None => Element::None,
-            Some(v) => Element::Word(Word::new(v)),
-        })
-        .collect())
-}
-
-fn pydataframe_to_frame<'a>(
-    frame_idx: usize,
-    record_schema: &RecordSchema,
-    dataframe: &'a PyDataFrame,
-    column_names: &Vec<String>,
-) -> PyResult<Frame<'a>> {
-    let mut columns = Vec::new();
-    for (column_name, field_schema) in column_names.iter().zip(record_schema.fields.iter()) {
-        let column = dataframe
-            .0
-            .column(&column_name)
-            .map_err(PyPolarsErr::from)?;
-        columns.push(pyserie_to_vec(
-            field_schema,
-            column.as_series().expect("invalid polars column type"),
-        )?);
-    }
-
-    Ok(Frame::new(frame_idx, columns))
-}
+use super::{casting, schema::RecordSchema, TrackingConfig};
 
 #[pyfunction]
 pub fn test_tracking_engine(
+    tracking_config: &TrackingConfig,
     record_schema: &RecordSchema,
     dataframes: Vec<PyDataFrame>,
-    column_names: Vec<String>,
 ) -> PyResult<()> {
-    wrapper(record_schema, &dataframes, column_names)
+    wrapper(tracking_config, record_schema, &dataframes)
 }
 
 fn wrapper<'a>(
+    tracking_config: &TrackingConfig,
     record_schema: &RecordSchema,
     dataframes: &'a Vec<PyDataFrame>,
-    column_names: Vec<String>,
 ) -> PyResult<()> {
     let mut frames = Vec::new();
     for i in 0..dataframes.len() {
-        let frame = pydataframe_to_frame(i, record_schema, &dataframes[i], &column_names)?;
+        let frame = casting::cast_to_frame(i, record_schema, &dataframes[i])?;
         frames.push(frame);
     }
 
-    let resolving_strategy = SimpleResolvingStrategy {};
-
-    let resolver = Resolver::new(Box::new(resolving_strategy));
-
-    let distance_calculators: Vec<CachedDistanceCalculator> = (0..column_names.len())
-        .map(|_| {
-            CachedDistanceCalculator::Word(CachedDistanceCalculatorWord::new(
-                Box::new(LvOptiDistanceMetric::new()),
-                4,
-            ))
-        })
-        .collect();
-
-    let tracker_builder = || {
-        let config = SimpleTrackerConfig {
-            interest_threshold: 0.7,
-        };
-        let tracker = Box::new(SimpleTracker::new(config));
-        // Safety: there is some unclear lifetime issue with the tracker
-        // that is not resolved yet. This is a temporary workaround.
-        unsafe { std::mem::transmute::<Box<dyn Tracker<'static>>, Box<dyn Tracker<'a>>>(tracker) }
-    };
-
     let mut tracking_engine =
-        TrackingEngine::new(frames, resolver, distance_calculators, tracker_builder);
+        casting::build_tracking_engine(tracking_config, record_schema, frames)?;
 
     tracking_engine.initialize_trackers();
 
@@ -99,6 +33,8 @@ fn wrapper<'a>(
     }
 
     let tracking_chains = tracking_engine.collect_tracking_chains();
+
+    println!("n chains: {}", tracking_chains.len());
 
     Ok(())
 }

--- a/src/distances/distance_matrix.rs
+++ b/src/distances/distance_matrix.rs
@@ -1,14 +1,20 @@
-use std::{collections::HashMap, hash::Hash};
+use std::{
+    collections::HashMap,
+    hash::{DefaultHasher, Hash, Hasher},
+};
 
 /// DistanceMatrix
 ///
 /// This is a building block for a cache, it stores the distances between elements.
 /// To work properly, the distance between element must be symmetric, that is dist(a, b) == dist(b, a).
-pub struct DistanceMatrix<K: Hash> {
-    values: HashMap<(K, K), f32>,
+///
+/// Note: the distance matrix computes the hashes of the keys passed to avoid having a reference
+/// as key, to avoid lifetime complications.
+pub struct DistanceMatrix {
+    values: HashMap<u64, f32>,
 }
 
-impl<K: Hash + Eq + Ord> DistanceMatrix<K> {
+impl DistanceMatrix {
     pub fn new() -> Self {
         Self {
             values: HashMap::new(),
@@ -25,19 +31,28 @@ impl<K: Hash + Eq + Ord> DistanceMatrix<K> {
         self.values.len()
     }
 
-    /// Sets the distance between v1 and v2.
-    pub fn set(&mut self, mut v1: K, mut v2: K, dist: f32) {
+    /// Hashes two keys and returns the hash.
+    ///
+    /// Keys are ordered before hashing, such that hash(a, b) == hash(b, a)
+    fn hash<K: Hash + Eq + Ord>(v1: &K, v2: &K) -> u64 {
+        let mut hasher = DefaultHasher::new();
         if v2 < v1 {
-            (v1, v2) = (v2, v1);
+            v2.hash(&mut hasher);
+            v1.hash(&mut hasher);
+        } else {
+            v1.hash(&mut hasher);
+            v2.hash(&mut hasher);
         }
-        self.values.insert((v1, v2), dist);
+        hasher.finish()
+    }
+
+    /// Sets the distance between v1 and v2.
+    pub fn set<K: Hash + Eq + Ord>(&mut self, v1: &K, v2: &K, dist: f32) {
+        self.values.insert(Self::hash(v1, v2), dist);
     }
 
     /// Returns the distance between v1 and v2.
-    pub fn get(&self, mut v1: K, mut v2: K) -> Option<f32> {
-        if v2 < v1 {
-            (v1, v2) = (v2, v1);
-        }
-        self.values.get(&(v1, v2)).copied()
+    pub fn get<K: Hash + Eq + Ord>(&self, v1: &K, v2: &K) -> Option<f32> {
+        self.values.get(&Self::hash(v1, v2)).copied()
     }
 }

--- a/src/distances/distance_metric.rs
+++ b/src/distances/distance_metric.rs
@@ -98,7 +98,7 @@ impl LvDistanceMetric {
     }
 }
 
-impl DistanceMetric<Word<'_>> for LvDistanceMetric {
+impl DistanceMetric<Word> for LvDistanceMetric {
     fn dist(&mut self, v1: &Word, v2: &Word) -> f32 {
         let edits = self.compute_edits(v1, v2);
         1.0 - edits as f32 / usize::max(v1.raw.len(), v2.raw.len()) as f32
@@ -137,7 +137,7 @@ impl LvOptiDistanceMetric {
         self.dp.fill(0);
     }
 
-    fn compute_edits<'a>(&mut self, mut w1: &'a Word<'a>, mut w2: &'a Word<'a>) -> u8 {
+    fn compute_edits<'a>(&mut self, mut w1: &'a Word, mut w2: &'a Word) -> u8 {
         let mut len_w1 = w1.graphemes.len();
         let mut len_w2 = w2.graphemes.len();
 
@@ -198,7 +198,7 @@ impl LvOptiDistanceMetric {
     }
 }
 
-impl DistanceMetric<Word<'_>> for LvOptiDistanceMetric {
+impl DistanceMetric<Word> for LvOptiDistanceMetric {
     fn dist(&mut self, v1: &Word, v2: &Word) -> f32 {
         let edits = self.compute_edits(v1, v2);
         1.0 - edits as f32 / usize::max(v1.raw.len(), v2.raw.len()) as f32

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -6,10 +6,10 @@ use crate::word::Word;
 /// - Word: A single `Word`
 /// - MultiWords: A collection of multiple `Word`
 /// - `None`: An empty element
-#[derive(Clone)]
-pub enum Element<'a> {
-    Word(Word<'a>),
-    MultiWords(Vec<Word<'a>>),
+#[derive(Clone, Debug)]
+pub enum Element {
+    Word(Word),
+    MultiWords(Vec<Word>),
     None,
 }
 
@@ -18,13 +18,13 @@ pub enum Element<'a> {
 /// A `Record` is composed of multiple `Element`s, each corresponding to a column
 /// in the `Frame`.
 #[derive(Default, Clone)]
-pub struct Record<'a> {
-    elements: Vec<Element<'a>>,
+pub struct Record {
+    elements: Vec<Element>,
 }
 
-impl<'a> Record<'a> {
+impl Record {
     /// Creates a new `Record` from a vector of `Element`s.
-    pub fn new(elements: Vec<Element<'a>>) -> Self {
+    pub fn new(elements: Vec<Element>) -> Self {
         Self { elements }
     }
 
@@ -42,7 +42,7 @@ impl<'a> Record<'a> {
     /// # Panics
     ///
     /// Panics if the index is out of bounds.
-    pub fn element(&self, idx: usize) -> &Element<'a> {
+    pub fn element(&self, idx: usize) -> &Element {
         &self.elements[idx]
     }
 }
@@ -52,15 +52,15 @@ impl<'a> Record<'a> {
 /// The `Frame` stores data in a column-major format, meaning each column contains
 /// all values for a specific feature across all records. This improves cache
 /// locality when processing data column-wise.
-pub struct Frame<'a> {
+pub struct Frame {
     idx: usize,
-    columns: Vec<Vec<Element<'a>>>,
+    columns: Vec<Vec<Element>>,
 }
 
-impl<'a> Frame<'a> {
+impl Frame {
     /// Creates a new `Frame` from a vector of columns, where each column
     /// contains elements for all records.
-    pub fn new(idx: usize, columns: Vec<Vec<Element<'a>>>) -> Self {
+    pub fn new(idx: usize, columns: Vec<Vec<Element>>) -> Self {
         Self { idx, columns }
     }
 
@@ -88,12 +88,12 @@ impl<'a> Frame<'a> {
     /// # Panics
     ///
     /// Panics if the index is out of bounds.
-    pub fn column(&self, idx: usize) -> &Vec<Element<'a>> {
+    pub fn column(&self, idx: usize) -> &Vec<Element> {
         &self.columns[idx]
     }
 
     /// Returns a new `Record` from the elements at the specified index across all columns.
-    pub fn record(&self, idx: usize) -> Record<'a> {
+    pub fn record(&self, idx: usize) -> Record {
         Record::new(self.columns.iter().map(|col| col[idx].clone()).collect())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,12 @@ fn blitzbeaver(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<api::FieldSchema>()?;
     m.add_class::<api::ElementType>()?;
 
+    m.add_class::<api::TrackingConfig>()?;
+    m.add_class::<api::ResolverConfig>()?;
+    m.add_class::<api::DistanceMetricConfig>()?;
+    m.add_class::<api::TrackerConfig>()?;
+    m.add_class::<api::SimpleTrackerConfig>()?;
+
     m.add_function(wrap_pyfunction!(api::test_tracking_engine, m)?)?;
 
     #[cfg(feature = "benchmark")]

--- a/src/resolvers/resolver.rs
+++ b/src/resolvers/resolver.rs
@@ -38,7 +38,7 @@ impl ScoreBucket {
 ///
 /// Responsible to decide which records match to which trackers and to create
 /// new trackers.
-pub trait ResolvingStrategy<'a> {
+pub trait ResolvingStrategy {
     /// Resolves the matching records to the trackers for the current frame.
     ///
     /// # Arguments
@@ -54,22 +54,22 @@ pub trait ResolvingStrategy<'a> {
     /// A list of new trackers.
     fn resolve(
         &mut self,
-        frame: &Frame<'a>,
-        trackers: &mut Vec<Box<dyn Tracker<'a>>>,
+        frame: &Frame,
+        trackers: &mut Vec<Box<dyn Tracker>>,
         buckets: Vec<ScoreBucket>,
         trackers_scores: Vec<Vec<RecordScore>>,
-    ) -> Vec<Box<dyn Tracker<'a>>>;
+    ) -> Vec<Box<dyn Tracker>>;
 }
 
 /// Resolver
 ///
 /// Responsible for applying the resolving strategy given the trackers scores.
-pub struct Resolver<'a> {
-    resolving_strategy: Box<dyn ResolvingStrategy<'a>>,
+pub struct Resolver {
+    resolving_strategy: Box<dyn ResolvingStrategy>,
 }
 
-impl<'a> Resolver<'a> {
-    pub fn new(resolving_strategy: Box<dyn ResolvingStrategy<'a>>) -> Self {
+impl Resolver {
+    pub fn new(resolving_strategy: Box<dyn ResolvingStrategy>) -> Self {
         Self { resolving_strategy }
     }
 
@@ -85,10 +85,10 @@ impl<'a> Resolver<'a> {
     /// A list of new trackers.
     pub fn resolve(
         &mut self,
-        frame: &Frame<'a>,
-        trackers: &mut Vec<Box<dyn Tracker<'a>>>,
+        frame: &Frame,
+        trackers: &mut Vec<Box<dyn Tracker>>,
         trackers_scores: Vec<Vec<RecordScore>>,
-    ) -> Vec<Box<dyn Tracker<'a>>> {
+    ) -> Vec<Box<dyn Tracker>> {
         let mut buckets = (0..frame.num_records())
             .into_iter()
             .map(|_| ScoreBucket::new())

--- a/src/resolvers/simple_resolving_strategy.rs
+++ b/src/resolvers/simple_resolving_strategy.rs
@@ -7,14 +7,14 @@ use super::{ResolvingStrategy, ScoreBucket};
 
 pub struct SimpleResolvingStrategy {}
 
-impl<'a> ResolvingStrategy<'a> for SimpleResolvingStrategy {
+impl ResolvingStrategy for SimpleResolvingStrategy {
     fn resolve(
         &mut self,
-        frame: &Frame<'a>,
-        trackers: &mut Vec<Box<dyn Tracker<'a>>>,
+        frame: &Frame,
+        trackers: &mut Vec<Box<dyn Tracker>>,
         buckets: Vec<ScoreBucket>,
         trackers_scores: Vec<Vec<RecordScore>>,
-    ) -> Vec<Box<dyn Tracker<'a>>> {
+    ) -> Vec<Box<dyn Tracker>> {
         for tracker_idx in 0..trackers.len() {
             let scores = &trackers_scores[tracker_idx];
             if scores.len() == 0 {

--- a/src/trackers.rs
+++ b/src/trackers.rs
@@ -1,5 +1,5 @@
 mod simple_tracker;
 mod tracker;
 
-pub use simple_tracker::{SimpleTracker, SimpleTrackerConfig};
+pub use simple_tracker::SimpleTracker;
 pub use tracker::{RecordScore, Tracker, TrackingNode};

--- a/src/trackers/simple_tracker.rs
+++ b/src/trackers/simple_tracker.rs
@@ -8,14 +8,14 @@ use crate::{
 use super::tracker::{RecordScore, Tracker, TrackingNode};
 
 #[derive(Clone)]
-pub struct SimpleTracker<'a> {
+pub struct SimpleTracker {
     id: ID,
     config: SimpleTrackerConfig,
     chain: Vec<TrackingNode>,
-    record: Record<'a>,
+    record: Record,
 }
 
-impl<'a> SimpleTracker<'a> {
+impl SimpleTracker {
     pub fn new(config: SimpleTrackerConfig) -> Self {
         Self {
             id: id::new_id(),
@@ -27,8 +27,8 @@ impl<'a> SimpleTracker<'a> {
 
     pub fn compute_distances(
         &self,
-        frame: &Frame<'a>,
-        distance_calculators: &mut Vec<CachedDistanceCalculator<'a>>,
+        frame: &Frame,
+        distance_calculators: &mut Vec<CachedDistanceCalculator>,
     ) -> Vec<Vec<f32>> {
         let mut distances = Vec::new();
 
@@ -50,7 +50,7 @@ impl<'a> SimpleTracker<'a> {
 
     pub fn compute_score_record(
         &self,
-        frame: &Frame<'a>,
+        frame: &Frame,
         distances: &Vec<Vec<f32>>,
         record_idx: usize,
     ) -> f32 {
@@ -62,7 +62,7 @@ impl<'a> SimpleTracker<'a> {
     }
 }
 
-impl<'a> Tracker<'a> for SimpleTracker<'a> {
+impl Tracker for SimpleTracker {
     fn id(&self) -> ID {
         self.id
     }
@@ -77,15 +77,15 @@ impl<'a> Tracker<'a> for SimpleTracker<'a> {
 
     fn signal_no_matching_node(&mut self) {}
 
-    fn add_node(&mut self, node: TrackingNode, record: Record<'a>) {
+    fn add_node(&mut self, node: TrackingNode, record: Record) {
         self.record = record;
         self.chain.push(node);
     }
 
     fn process_frame(
         &mut self,
-        frame: &Frame<'a>,
-        distance_calculators: &mut Vec<CachedDistanceCalculator<'a>>,
+        frame: &Frame,
+        distance_calculators: &mut Vec<CachedDistanceCalculator>,
     ) -> Vec<RecordScore> {
         let distances = self.compute_distances(frame, distance_calculators);
 

--- a/src/trackers/simple_tracker.rs
+++ b/src/trackers/simple_tracker.rs
@@ -1,15 +1,11 @@
 use crate::{
+    api::SimpleTrackerConfig,
     distances::CachedDistanceCalculator,
     frame::{Frame, Record},
     id::{self, ID},
 };
 
 use super::tracker::{RecordScore, Tracker, TrackingNode};
-
-#[derive(Clone)]
-pub struct SimpleTrackerConfig {
-    pub interest_threshold: f32,
-}
 
 #[derive(Clone)]
 pub struct SimpleTracker<'a> {

--- a/src/trackers/tracker.rs
+++ b/src/trackers/tracker.rs
@@ -44,7 +44,7 @@ impl Ord for RecordScore {
 ///
 /// Responsible to track an individual through multiple frames.
 /// Each tracker produces a single tracking chain.
-pub trait Tracker<'a> {
+pub trait Tracker {
     /// Returns the ID of the tracker
     fn id(&self) -> ID;
 
@@ -66,7 +66,7 @@ pub trait Tracker<'a> {
     /// The matching record is also provided to update the tracker's memory.
     ///
     /// In case no matching node is found, the `signal_no_matching_node` method is called instead.
-    fn add_node(&mut self, node: TrackingNode, record: Record<'a>);
+    fn add_node(&mut self, node: TrackingNode, record: Record);
 
     /// Processes a frame, that is computes the distances between the tracker's memory
     /// and the frame's records to find the "best" records.
@@ -75,7 +75,7 @@ pub trait Tracker<'a> {
     /// The list must be sorted in descending order of score.
     fn process_frame(
         &mut self,
-        frame: &Frame<'a>,
-        distance_calculators: &mut Vec<CachedDistanceCalculator<'a>>,
+        frame: &Frame,
+        distance_calculators: &mut Vec<CachedDistanceCalculator>,
     ) -> Vec<RecordScore>;
 }

--- a/src/tracking_engine.rs
+++ b/src/tracking_engine.rs
@@ -5,27 +5,27 @@ use crate::{
     trackers::{Tracker, TrackingNode},
 };
 
-pub struct TrackingEngine<'a, F>
+pub struct TrackingEngine<F>
 where
-    F: Fn() -> Box<dyn Tracker<'a>> + 'a,
+    F: Fn() -> Box<dyn Tracker>,
 {
-    frames: Vec<Frame<'a>>,
-    resolver: Resolver<'a>,
-    distance_calculators: Vec<CachedDistanceCalculator<'a>>,
-    trackers: Vec<Box<dyn Tracker<'a>>>,
+    frames: Vec<Frame>,
+    resolver: Resolver,
+    distance_calculators: Vec<CachedDistanceCalculator>,
+    trackers: Vec<Box<dyn Tracker>>,
     tracker_builder: F,
     dead_tracking_chains: Vec<Vec<TrackingNode>>,
     next_frame_idx: usize,
 }
 
-impl<'a, F> TrackingEngine<'a, F>
+impl<F> TrackingEngine<F>
 where
-    F: Fn() -> Box<dyn Tracker<'a>> + 'a,
+    F: Fn() -> Box<dyn Tracker>,
 {
     pub fn new(
-        frames: Vec<Frame<'a>>,
-        resolver: Resolver<'a>,
-        distance_calculators: Vec<CachedDistanceCalculator<'a>>,
+        frames: Vec<Frame>,
+        resolver: Resolver,
+        distance_calculators: Vec<CachedDistanceCalculator>,
         tracker_builder: F,
     ) -> Self {
         Self {

--- a/src/word.rs
+++ b/src/word.rs
@@ -4,21 +4,25 @@ use unicode_segmentation::UnicodeSegmentation;
 ///
 /// This is a string type that is optimized for distance calculations.
 ///
+/// The raw string is owned and not a reference to the original string because of
+/// complications with lifetime management. Also the array of clusters takes more
+/// memory than the raw string anyway.
+///
 /// The graphemes store the same string as a sequence of grapheme clusters.
 /// Each grapheme is stored as a u64, this is an optimization and is not always valid
 /// (that is there exists grapheme that are larger than 8 bytes). However in practice
 /// grapheme will (almost) always be smaller than 8 bytes.
-#[derive(Hash, PartialEq, Eq, Clone)]
-pub struct Word<'a> {
-    pub raw: &'a str,
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
+pub struct Word {
+    pub raw: String,
     pub graphemes: Vec<u64>,
 }
 
-impl<'a> Word<'a> {
-    pub fn new(raw: &'a str) -> Self {
+impl Word {
+    pub fn new(raw: String) -> Self {
         Self {
-            raw,
             graphemes: raw
+                .as_str()
                 .graphemes(true)
                 .map(|g| {
                     if g.len() > 8 {
@@ -29,6 +33,7 @@ impl<'a> Word<'a> {
                     }
                 })
                 .collect(),
+            raw,
         }
     }
 


### PR DESCRIPTION
#### Config
Create configuration classes to set up the tracking engine (so all tracking related configuration).

#### Casting
* Create functions to cast from a polars dataframe to a `Frame` according to the `RecordSchema`
* Create functions to build a `TrackingEngine` instance from the config

Also remove all lifetimes, now `Word` own the string and no longer a reference. This was done because the lifetime management became very complicated when integrating with the polars dataframe.

Close #3
Close #4 