### PR TITLE
Precompute cache per worker

### DIFF
--- a/src/distances/distance_matrix.rs
+++ b/src/distances/distance_matrix.rs
@@ -10,6 +10,7 @@ use std::{
 ///
 /// Note: the distance matrix computes the hashes of the keys passed to avoid having a reference
 /// as key, to avoid lifetime complications.
+#[derive(Clone)]
 pub struct DistanceMatrix {
     values: HashMap<u64, f32>,
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,6 @@
 mod engine;
+mod exclusive_shared;
 mod worker;
 
 pub use engine::{EngineConfig, TrackingEngine};
+pub use exclusive_shared::ExclusiveShared;

--- a/src/engine/exclusive_shared.rs
+++ b/src/engine/exclusive_shared.rs
@@ -1,0 +1,45 @@
+use std::{ops::Deref, sync::Arc};
+
+/// Smart pointer for shared values with unchecked exclusive access.
+///
+/// This is useful when synchronization is handled by some external mechanism,
+/// rendering the overhead of a lock (mutex) unnecessary.
+pub struct ExclusiveShared<T>(Arc<T>)
+where
+    T: Send + Sync;
+
+impl<T> ExclusiveShared<T>
+where
+    T: Send + Sync,
+{
+    pub fn new(value: T) -> Self {
+        Self(Arc::new(value))
+    }
+
+    /// Returns a mutable reference to the value.
+    ///
+    /// This method is safe if no other thread as access to the value.
+    pub fn exclusive(&mut self) -> &mut T {
+        unsafe { &mut *(Arc::as_ptr(&self.0) as *mut T) }
+    }
+}
+
+impl<T> Deref for ExclusiveShared<T>
+where
+    T: Send + Sync,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Clone for ExclusiveShared<T>
+where
+    T: Send + Sync,
+{
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}

--- a/src/resolvers/simple_resolving_strategy.rs
+++ b/src/resolvers/simple_resolving_strategy.rs
@@ -1,7 +1,6 @@
-use std::sync::{Arc, Mutex};
-
 use crate::{
     api::ChainNode,
+    engine::ExclusiveShared,
     frame::Frame,
     trackers::{InternalTrackerConfig, RecordScore, Tracker},
 };
@@ -15,12 +14,12 @@ impl ResolvingStrategy for SimpleResolvingStrategy {
         &mut self,
         frame: &Frame,
         tracker_config: InternalTrackerConfig,
-        trackers: &Vec<Arc<Mutex<Tracker>>>,
+        trackers: &mut Vec<ExclusiveShared<Tracker>>,
         buckets: Vec<ScoreBucket>,
         trackers_scores: Vec<Vec<RecordScore>>,
     ) -> Vec<Tracker> {
         for tracker_idx in 0..trackers.len() {
-            let mut tracker = trackers[tracker_idx].lock().unwrap();
+            let tracker = trackers[tracker_idx].exclusive();
             let scores = &trackers_scores[tracker_idx];
             if scores.len() == 0 {
                 tracker.signal_no_matching_node();

--- a/src/trackers/tracker_memory.rs
+++ b/src/trackers/tracker_memory.rs
@@ -108,12 +108,12 @@ impl TrackerMemory for MostFrequentMemory {
 /// - Long term memory: returns the elements of the composed memory.
 /// - Short term memory: returns the latest element that has been seen.
 pub struct LongShortTermMemory {
-    long_memory: Box<dyn TrackerMemory + Send>,
+    long_memory: Box<dyn TrackerMemory + Send + Sync>,
     latest_element: Option<Element>,
 }
 
 impl LongShortTermMemory {
-    pub fn new(long_memory: Box<dyn TrackerMemory + Send>) -> Self {
+    pub fn new(long_memory: Box<dyn TrackerMemory + Send + Sync>) -> Self {
         Self {
             long_memory,
             latest_element: None,


### PR DESCRIPTION
Updates the setup of the distance calculators caches to:
* Precomputes the caches using the trackers memories (as opposed to the last frame) with the next frame, this allows for a higher cache hit rate
* Computes and stores the caches per worker (as opposed to one shared cache managed by the main thread), this is actually faster (as explained in the code)

Also remove the mutexes on the trackers, they are not needed since only a single worker or the main thread can access a tracker at any given time (this needed the creation of a wrapper time to deal with Rust safety rules).

Close #26 