### PR TITLE
fix access tracker memory

### DIFF
--- a/python/blitzbeaver/blitzbeaver.pyi
+++ b/python/blitzbeaver/blitzbeaver.pyi
@@ -215,16 +215,22 @@ class Diagnostics:
     scoring process of the trackers.
     """
 
-    trackers: dict[ID, TrackerDiagnostics]
-    """
-    Diagnostic information for all the trackers
-    that were created during the tracking process.
-    """
     resolvings: list[ResolvingDiagnostics]
     """
     Diagnostic information about the resolving process
     for each frame.
     """
+
+    def get_tracker(self, id: ID) -> TrackerDiagnostics | None:
+        """
+        Get the diagnostic information for the tracker with the given ID.
+
+        Args:
+            id: ID of the tracker
+
+        Returns:
+            Diagnostic information of the tracker or None if not found.
+        """
 
 # Beaver
 


### PR DESCRIPTION
Fix the performance issue when accessing the trackers diagnostics, it was caused by exposing the `Diagnostics.trackers` hash map to Python. Now a method `Diagnostics.get_tracker` can be used to access a tracker's diagnostics.

Close #38 