### PR TITLE
Refactore ID

### DIFF
--- a/python/blitzbeaver/literals.py
+++ b/python/blitzbeaver/literals.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-ID = tuple[int, int]
+ID = int
 
 Element = str | list[str] | None
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,7 +1,8 @@
 /// Unique ID type
-pub type ID = (u64, u64);
+pub type ID = u64;
 
 /// Returns a new unique ID
 pub fn new_id() -> ID {
-    uuid::Uuid::new_v4().as_u64_pair()
+    let (hi, lo) = uuid::Uuid::new_v4().as_u64_pair();
+    hi ^ lo
 }


### PR DESCRIPTION
Refactore the ID type to be on 8 bytes: `u64` instead of `(u64, u64)` (`int` instead of `tuple[int, int]` in Python)