### PR TITLE
Publish blitzbeaver on PyPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "blitzbeaver"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "bit-set",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blitzbeaver"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Alexandre Goumaz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,21 @@ build-backend = "maturin"
 
 [project]
 name = "blitzbeaver"
+description = "Persons tracking accross historical records."
+readme = "readme.md"
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dynamic = ["version"]
-[project.optional-dependencies]
-tests = ["pytest"]
+version = "1.0.0"
+dependencies = ["polars>=1.19.0,<2", "pyarrow>=19.0.0,<20.0.0"]
+authors = [
+    { name = "Alexandre Goumaz", email = "alexandre.goumaz@epfl.ch" },
+    { name = "Timo Moebel", email = "timo.moebel@epfl.ch" },
+]
+[project.urls]
+Repository = "https://github.com/Plouc314/blitzbeaver"
 [tool.maturin]
 python-source = "python"
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
Set up the library to be published on PyPI.

Chose the MIT license (may change).